### PR TITLE
[role:build-essentials] add jq, mysql-dev, kernel parameters

### DIFF
--- a/roles/build-essential/tasks/kernel_param.yml
+++ b/roles/build-essential/tasks/kernel_param.yml
@@ -1,0 +1,9 @@
+---
+
+- name: update inotify max_user_watches
+  become: yes
+  sysctl:
+    name: fs.inotify.max_user_watches
+    value: '524288'
+    reload: yes
+

--- a/roles/build-essential/tasks/main.yml
+++ b/roles/build-essential/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 
-- name: build-essentials | be sure build-essential is installed
+- name: be sure build-essential is installed
   become: yes
   apt: name=build-essential
        state=latest
 
-- name: build-essential | install make tools
+- name: install make tools
   become: yes
   apt:
     name: "{{ packages }}"

--- a/roles/build-essential/tasks/main.yml
+++ b/roles/build-essential/tasks/main.yml
@@ -16,3 +16,7 @@
     - texinfo
     - unzip
     - jq
+    - libmysqlclient-dev
+    - sysstat
+
+- include_tasks: kernel_param.yml

--- a/roles/build-essential/tasks/main.yml
+++ b/roles/build-essential/tasks/main.yml
@@ -15,3 +15,4 @@
     - make
     - texinfo
     - unzip
+    - jq


### PR DESCRIPTION
fixed in build-essentials role:

* Install jq and mysql-dev.
* Configure kernel prameteters (ionotify).