### PR TITLE
Install libyaml-dev for ruby

### DIFF
--- a/roles/ruby/tasks/required_libs_Ubuntu.yml
+++ b/roles/ruby/tasks/required_libs_Ubuntu.yml
@@ -12,4 +12,5 @@
       - libssl-dev
       - libffi-dev
       - libreadline-dev
+      - libyaml-dev
       - zlib1g-dev


### PR DESCRIPTION
Ruby 3.2 require libyaml

see: https://www.ruby-lang.org/ja/news/2022/12/25/ruby-3-2-0-released/